### PR TITLE
db: make databases per server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ ipython_config.py
 
 # databases
 local.db
+guilds
 
 .env
 node_modules

--- a/src/commands/mod/logs.js
+++ b/src/commands/mod/logs.js
@@ -16,7 +16,8 @@ export default {
 
   async execute(interaction) {
     const user = interaction.options.getUser("user");
-    const userData = await getUser(user.id);
+    const guildId = interaction.guildId;
+    const userData = await getUser(user.id, guildId);
 
     if (!userData?.warns?.length) {
       return interaction.reply({

--- a/src/commands/mod/warn.js
+++ b/src/commands/mod/warn.js
@@ -29,7 +29,8 @@ export default {
 
     try {
       const user = interaction.options.getUser("user");
-      let userData = await getUser(user.id);
+      const guildId = interaction.guildId;
+      let userData = await getUser(user.id, guildId);
       let warns = userData?.warns || [];
 
       warns.push({
@@ -39,9 +40,9 @@ export default {
       });
 
       if (!userData) {
-        await createUser(user.id, warns);
+        await createUser(user.id, guildId, warns);
       } else {
-        await updateUserWarns(user.id, warns);
+        await updateUserWarns(user.id, guildId, warns);
       }
 
       interaction.reply({

--- a/src/schemas/user.js
+++ b/src/schemas/user.js
@@ -1,12 +1,16 @@
-export async function getUser(userId) {
-  const cachedUser = await global.redis.get(`user:${userId}`);
+import { getGuildDB } from "../utils/dbManager.js";
+
+export async function getUser(userId, guildId) {
+  const cacheKey = `guild:${guildId}:user:${userId}`;
+  const cachedUser = await global.redis.get(cacheKey);
   if (cachedUser) {
     return JSON.parse(cachedUser);
   }
 
-  const result = await global.libsql.execute({
-    sql: "SELECT * FROM users WHERE id = ?",
-    args: [userId],
+  const guildDB = await getGuildDB(guildId);
+  const result = await guildDB.execute({
+    sql: "SELECT * FROM users WHERE id = ? AND guild_id = ?",
+    args: [userId, guildId],
   });
 
   if (result.rows.length === 0) {
@@ -14,32 +18,37 @@ export async function getUser(userId) {
   }
 
   const user = result.rows[0];
-  await global.redis.set(`user:${userId}`, JSON.stringify(user), "EX", 3600);
+  await global.redis.set(cacheKey, JSON.stringify(user));
   return user;
 }
 
-export async function createUser(userId, warns = []) {
+export async function createUser(userId, guildId, warns = []) {
   const user = {
     id: userId,
+    guild_id: guildId,
     warns,
   };
 
-  await global.libsql.execute({
-    sql: "INSERT INTO users (id, warns) VALUES (?, ?)",
-    args: [userId, JSON.stringify(warns)],
+  const guildDB = await getGuildDB(guildId);
+  await guildDB.execute({
+    sql: "INSERT INTO users (id, guild_id, warns) VALUES (?, ?, ?)",
+    args: [userId, guildId, JSON.stringify(warns)],
   });
 
-  await global.redis.set(`user:${userId}`, JSON.stringify(user), "EX", 3600);
+  const cacheKey = `guild:${guildId}:user:${userId}`;
+  await global.redis.set(cacheKey, JSON.stringify(user));
   return user;
 }
 
-export async function updateUserWarns(userId, warns) {
-  await global.libsql.execute({
-    sql: "UPDATE users SET warns = ? WHERE id = ?",
-    args: [JSON.stringify(warns), userId],
+export async function updateUserWarns(userId, guildId, warns) {
+  const guildDB = await getGuildDB(guildId);
+  await guildDB.execute({
+    sql: "UPDATE users SET warns = ? WHERE id = ? AND guild_id = ?",
+    args: [JSON.stringify(warns), userId, guildId],
   });
 
-  const user = { id: userId, warns };
-  await global.redis.set(`user:${userId}`, JSON.stringify(user), "EX", 3600);
+  const user = { id: userId, guild_id: guildId, warns };
+  const cacheKey = `guild:${guildId}:user:${userId}`;
+  await global.redis.set(cacheKey, JSON.stringify(user));
   return user;
 }

--- a/src/utils/dbManager.js
+++ b/src/utils/dbManager.js
@@ -1,0 +1,43 @@
+import { createClient } from "@libsql/client";
+import path from "path";
+import fs from "fs";
+
+const guildConnections = new Map();
+
+async function ensureGuildDirectory() {
+  const guildDir = path.join(process.cwd(), "guilds");
+  if (!fs.existsSync(guildDir)) {
+    fs.mkdirSync(guildDir, { recursive: true });
+  }
+}
+
+export async function getGuildDB(guildId) {
+  if (guildConnections.has(guildId)) {
+    return guildConnections.get(guildId);
+  }
+
+  await ensureGuildDirectory();
+
+  const dbPath = path.join(process.cwd(), `guilds/${guildId}.db`);
+  const libsql = createClient({
+    url: process.env.LIBSQL_URL
+      ? `${process.env.LIBSQL_URL}/${guildId}`
+      : `file:${dbPath}`,
+    authToken: process.env.LIBSQL_AUTH_TOKEN,
+  });
+
+  await initGuildDB(libsql);
+  guildConnections.set(guildId, libsql);
+  return libsql;
+}
+
+async function initGuildDB(db) {
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT,
+      guild_id TEXT,
+      warns TEXT NOT NULL DEFAULT '[]',
+      PRIMARY KEY (id, guild_id)
+    )
+  `);
+}


### PR DESCRIPTION
## features
- modifies current database structure to be per server
- stores per server databases in guilds/ (excluded from being committed in .gitignore)
- removes cache timeout

example:

i warn myself once in this server and then run /logs on myself:
![image](https://github.com/user-attachments/assets/5f5e23ee-d5ef-4026-9946-2a0cc32c2e5e)

and then in the next server i warn myself twice and then run /logs on myself:

![image](https://github.com/user-attachments/assets/78c0edb6-223d-45ed-bb92-3d7842f1e2cb)

both servers have different logs and timestamps