### PR TITLE
feat: antiraid

### DIFF
--- a/migrations/002_create_guild_settings.sql
+++ b/migrations/002_create_guild_settings.sql
@@ -1,6 +1,11 @@
 CREATE TABLE IF NOT EXISTS guild_settings (
     guild_id TEXT PRIMARY KEY,
     log_channel_id TEXT,
+    prefix TEXT,
+    antiraid_enabled INTEGER DEFAULT 0,
+    antiraid_jail_channel TEXT,
+    antiraid_msg_threshold INTEGER DEFAULT 5,
+    antiraid_time_window INTEGER DEFAULT 5,
     created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
     updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );

--- a/src/commands/mod/antiraid.js
+++ b/src/commands/mod/antiraid.js
@@ -1,0 +1,205 @@
+import { SlashCommandBuilder, PermissionFlagsBits } from "discord.js";
+import { getGuildDB } from "../../utils/dbManager.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("antiraid")
+    .setDescription("Configure anti-raid protection")
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName("toggle")
+        .setDescription("Toggle anti-raid protection")
+        .addBooleanOption((option) =>
+          option
+            .setName("enabled")
+            .setDescription("Enable or disable anti-raid protection")
+            .setRequired(true)
+        )
+        .addChannelOption((option) =>
+          option
+            .setName("channel")
+            .setDescription("Channel to jail raiders in")
+            .setRequired(true)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName("threshold")
+        .setDescription("Set message threshold for raid detection")
+        .addIntegerOption((option) =>
+          option
+            .setName("messages")
+            .setDescription("Number of messages within timeframe to trigger")
+            .setRequired(true)
+            .setMinValue(3)
+            .setMaxValue(20)
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName("seconds")
+            .setDescription("Timeframe in seconds")
+            .setRequired(true)
+            .setMinValue(1)
+            .setMaxValue(60)
+        )
+    ),
+
+  async execute(interaction) {
+    if (
+      !interaction.member.permissions.has([PermissionFlagsBits.ManageGuild])
+    ) {
+      return interaction.reply({
+        content: "You don't have permission to use this command",
+        ephemeral: true,
+      });
+    }
+
+    const subcommand = interaction.options.getSubcommand();
+    const guildDB = await getGuildDB(interaction.guildId);
+
+    try {
+      if (subcommand === "toggle") {
+        const enabled = interaction.options.getBoolean("enabled");
+        const channel = interaction.options.getChannel("channel");
+
+        await guildDB.execute({
+          sql: `INSERT INTO guild_settings (guild_id, antiraid_enabled, antiraid_jail_channel) 
+                VALUES (?, ?, ?)
+                ON CONFLICT (guild_id) 
+                DO UPDATE SET antiraid_enabled = ?, antiraid_jail_channel = ?, updated_at = strftime('%s', 'now')`,
+          args: [interaction.guildId, enabled, channel.id, enabled, channel.id],
+        });
+
+        const cacheKey = `guild:${interaction.guildId}:settings`;
+        const settings = JSON.parse((await global.redis.get(cacheKey)) || "{}");
+        settings.antiraid_enabled = enabled;
+        settings.antiraid_jail_channel = channel.id;
+        await global.redis.set(cacheKey, JSON.stringify(settings));
+
+        return interaction.reply({
+          content: `Anti-raid protection has been ${enabled ? "enabled" : "disabled"} with jail channel set to ${channel}`,
+          ephemeral: true,
+        });
+      }
+
+      if (subcommand === "threshold") {
+        const messages = interaction.options.getInteger("messages");
+        const seconds = interaction.options.getInteger("seconds");
+
+        await guildDB.execute({
+          sql: `INSERT INTO guild_settings (guild_id, antiraid_msg_threshold, antiraid_time_window) 
+                VALUES (?, ?, ?)
+                ON CONFLICT (guild_id) 
+                DO UPDATE SET antiraid_msg_threshold = ?, antiraid_time_window = ?, updated_at = strftime('%s', 'now')`,
+          args: [interaction.guildId, messages, seconds, messages, seconds],
+        });
+
+        const cacheKey = `guild:${interaction.guildId}:settings`;
+        const settings = JSON.parse((await global.redis.get(cacheKey)) || "{}");
+        settings.antiraid_msg_threshold = messages;
+        settings.antiraid_time_window = seconds;
+        await global.redis.set(cacheKey, JSON.stringify(settings));
+
+        return interaction.reply({
+          content: `Anti-raid threshold set to ${messages} messages within ${seconds} seconds`,
+          ephemeral: true,
+        });
+      }
+    } catch (error) {
+      console.error(error);
+      return interaction.reply({
+        content: "An error occurred while configuring anti-raid protection",
+        ephemeral: true,
+      });
+    }
+  },
+
+  async prefixExecute(message, args) {
+    if (!message.member.permissions.has([PermissionFlagsBits.ManageGuild])) {
+      return message.reply("You don't have permission to use this command");
+    }
+
+    const subcommand = args[0]?.toLowerCase();
+    const guildDB = await getGuildDB(message.guildId);
+
+    try {
+      if (subcommand === "toggle") {
+        const enabled =
+          args[1]?.toLowerCase() === "true" || args[1]?.toLowerCase() === "on";
+        const channelId = args[2]?.replace(/[<#>]/g, "");
+
+        if (!channelId) {
+          return message.reply("Please provide a channel for jail");
+        }
+
+        const channel = message.guild.channels.cache.get(channelId);
+        if (!channel) {
+          return message.reply("Invalid channel");
+        }
+
+        await guildDB.execute({
+          sql: `INSERT INTO guild_settings (guild_id, antiraid_enabled, antiraid_jail_channel) 
+                VALUES (?, ?, ?)
+                ON CONFLICT (guild_id) 
+                DO UPDATE SET antiraid_enabled = ?, antiraid_jail_channel = ?, updated_at = strftime('%s', 'now')`,
+          args: [message.guildId, enabled, channel.id, enabled, channel.id],
+        });
+
+        const cacheKey = `guild:${message.guildId}:settings`;
+        const settings = JSON.parse((await global.redis.get(cacheKey)) || "{}");
+        settings.antiraid_enabled = enabled;
+        settings.antiraid_jail_channel = channel.id;
+        await global.redis.set(cacheKey, JSON.stringify(settings));
+
+        return message.reply(
+          `Anti-raid protection has been ${enabled ? "enabled" : "disabled"} with jail channel set to ${channel}`
+        );
+      }
+
+      if (subcommand === "threshold") {
+        const messages = parseInt(args[1]);
+        const seconds = parseInt(args[2]);
+
+        if (
+          !messages ||
+          !seconds ||
+          messages < 3 ||
+          messages > 20 ||
+          seconds < 1 ||
+          seconds > 60
+        ) {
+          return message.reply(
+            "Please provide valid threshold values (messages: 3-20, seconds: 1-60)"
+          );
+        }
+
+        await guildDB.execute({
+          sql: `INSERT INTO guild_settings (guild_id, antiraid_msg_threshold, antiraid_time_window) 
+                VALUES (?, ?, ?)
+                ON CONFLICT (guild_id) 
+                DO UPDATE SET antiraid_msg_threshold = ?, antiraid_time_window = ?, updated_at = strftime('%s', 'now')`,
+          args: [message.guildId, messages, seconds, messages, seconds],
+        });
+
+        const cacheKey = `guild:${message.guildId}:settings`;
+        const settings = JSON.parse((await global.redis.get(cacheKey)) || "{}");
+        settings.antiraid_msg_threshold = messages;
+        settings.antiraid_time_window = seconds;
+        await global.redis.set(cacheKey, JSON.stringify(settings));
+
+        return message.reply(
+          `Anti-raid threshold set to ${messages} messages within ${seconds} seconds`
+        );
+      }
+
+      return message.reply(
+        "Please provide a valid subcommand (toggle/channel/threshold)"
+      );
+    } catch (error) {
+      console.error(error);
+      return message.reply(
+        "An error occurred while configuring anti-raid protection"
+      );
+    }
+  },
+};

--- a/src/events/messageCreate/handleAntiRaid.js
+++ b/src/events/messageCreate/handleAntiRaid.js
@@ -1,0 +1,120 @@
+import { getGuildSettings } from "../../utils/dbManager.js";
+import handleServerLogs from "../serverEvents/handleServerLogs.js";
+
+const messageCache = new Map();
+const raidCache = new Map();
+const RAID_COOLDOWN = 60000;
+
+export default async (client, message) => {
+  if (message.author.bot || !message.guild) return;
+
+  try {
+    const settings = await getGuildSettings(message.guild.id);
+    if (!settings?.antiraid_enabled || !settings?.antiraid_jail_channel) return;
+
+    const threshold = settings.antiraid_msg_threshold || 5;
+    const timeWindow = (settings.antiraid_time_window || 5) * 1000;
+
+    const guildCache = messageCache.get(message.guild.id) || new Map();
+    const userMessages = guildCache.get(message.author.id) || [];
+    const now = Date.now();
+
+    userMessages.push(now);
+    userMessages.sort((a, b) => b - a);
+
+    while (
+      userMessages.length > 0 &&
+      now - userMessages[userMessages.length - 1] > timeWindow
+    ) {
+      userMessages.pop();
+    }
+
+    guildCache.set(message.author.id, userMessages);
+    messageCache.set(message.guild.id, guildCache);
+
+    const activeRaid = raidCache.get(message.guild.id);
+    if (activeRaid && now - activeRaid < RAID_COOLDOWN) return;
+
+    const suspiciousUsers = new Map();
+    for (const [userId, timestamps] of guildCache.entries()) {
+      if (timestamps.length >= threshold) {
+        suspiciousUsers.set(userId, timestamps.length);
+      }
+    }
+
+    if (suspiciousUsers.size >= 3) {
+      raidCache.set(message.guild.id, now);
+      const members = await Promise.all(
+        Array.from(suspiciousUsers.keys()).map((id) =>
+          message.guild.members.fetch(id).catch(() => null)
+        )
+      );
+
+      const validMembers = members.filter((m) => m && m.moderatable);
+      if (validMembers.length > 0) {
+        let jailRole = message.guild.roles.cache.find(
+          (role) => role.name === "Jailed"
+        );
+        if (!jailRole) {
+          jailRole = await message.guild.roles.create({
+            name: "Jailed",
+            color: "#36393f",
+            permissions: [],
+          });
+        }
+
+        const jailChannel = await client.channels.fetch(
+          settings.antiraid_jail_channel
+        );
+        const parentCategory = jailChannel.parent;
+
+        for (const member of validMembers) {
+          const userRoles = member.roles.cache.filter(
+            (role) => role.id !== message.guild.id
+          );
+          const removedRoles = [];
+
+          for (const role of userRoles.values()) {
+            removedRoles.push(role.id);
+            await member.roles.remove(role);
+          }
+
+          await member.roles.add(jailRole);
+        }
+
+        for (const channel of message.guild.channels.cache.values()) {
+          if (channel.id === jailChannel.id) {
+            await channel.permissionOverwrites.create(jailRole, {
+              ViewChannel: true,
+              SendMessages: true,
+              ReadMessageHistory: true,
+            });
+          } else if (channel.id === parentCategory?.id) {
+            await channel.permissionOverwrites.create(jailRole, {
+              ViewChannel: true,
+            });
+          } else {
+            await channel.permissionOverwrites.create(jailRole, {
+              ViewChannel: false,
+            });
+          }
+        }
+
+        await handleServerLogs(client, message.guild, "RAID_DETECTED", {
+          users: validMembers.map((m) => ({
+            id: m.id,
+            tag: m.user.tag,
+            messageCount: suspiciousUsers.get(m.id),
+          })),
+          channel: message.channel,
+          timeWindow: timeWindow / 1000,
+          action: "jailed",
+        });
+
+        messageCache.delete(message.guild.id);
+      }
+    }
+  } catch (error) {
+    console.error("[Error] Anti-raid handler failed:", error);
+  }
+};

--- a/src/utils/dbManager.js
+++ b/src/utils/dbManager.js
@@ -33,19 +33,29 @@ export async function getGuildDB(guildId) {
 
 async function migrateDB(db) {
   try {
-    const columns = await db.execute("PRAGMA table_info(users)");
-    const existingColumns = new Set(columns.rows.map((row) => row.name));
-
-    const requiredColumns = {
-      bans: "TEXT NOT NULL DEFAULT '[]'",
-      kicks: "TEXT NOT NULL DEFAULT '[]'",
-      timeouts: "TEXT NOT NULL DEFAULT '[]'",
-      jails: "TEXT NOT NULL DEFAULT '[]'",
+    const tables = {
+      users: {
+        bans: "TEXT NOT NULL DEFAULT '[]'",
+        kicks: "TEXT NOT NULL DEFAULT '[]'",
+        timeouts: "TEXT NOT NULL DEFAULT '[]'",
+        jails: "TEXT NOT NULL DEFAULT '[]'",
+      },
+      guild_settings: {
+        antiraid_enabled: "INTEGER DEFAULT 0",
+        antiraid_jail_channel: "TEXT",
+        antiraid_msg_threshold: "INTEGER DEFAULT 5",
+        antiraid_time_window: "INTEGER DEFAULT 5",
+      },
     };
 
-    for (const [column, type] of Object.entries(requiredColumns)) {
-      if (!existingColumns.has(column)) {
-        await db.execute(`ALTER TABLE users ADD COLUMN ${column} ${type}`);
+    for (const [table, columns] of Object.entries(tables)) {
+      const tableInfo = await db.execute(`PRAGMA table_info(${table})`);
+      const existingColumns = new Set(tableInfo.rows.map((row) => row.name));
+
+      for (const [column, type] of Object.entries(columns)) {
+        if (!existingColumns.has(column)) {
+          await db.execute(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);
+        }
       }
     }
   } catch (error) {
@@ -71,6 +81,11 @@ async function initGuildDB(db) {
     CREATE TABLE IF NOT EXISTS guild_settings (
       guild_id TEXT PRIMARY KEY,
       log_channel_id TEXT,
+      prefix TEXT,
+      antiraid_enabled INTEGER DEFAULT 0,
+      antiraid_jail_channel TEXT,
+      antiraid_msg_threshold INTEGER DEFAULT 5,
+      antiraid_time_window INTEGER DEFAULT 5,
       created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
       updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
     )


### PR DESCRIPTION
Enable/disable antiraid
Tracks messages per user
Triggers when multiple users spam
Default threshold: 5 messages in 5 seconds
Requires 3+ users spamming to trigger
Creates jailed role
Removes all roles from raiders
Adds jailed role to raiders
Has 60s cooldown between raids

Works with prefix, same syntax

Example usage:
/antiraid toggle true #jail-channel
/antiraid threshold 10 30

This would:
Enable antiraid
Set jail channel
Trigger on 10 messages within 30 seconds